### PR TITLE
enable cli only build gated by cargo features

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,13 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - run: rustup target add ${{ matrix.target }}
+        # Build the CLI only binary
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+      - run: mv "target/${{ matrix.target }}/release/ornithe-installer-rs" "target/${{ matrix.target }}/release/ornithe-installer-rs-cli.bin"
+        if: runner.os != 'Windows'
+      - run: mv "target/${{ matrix.target }}/release/ornithe-installer-rs.exe" "target/${{ matrix.target }}/release/ornithe-installer-rs-cli.exe"
+        if: runner.os == 'Windows'
+        # Regular build with GUI
       - run: cargo build --release --target ${{ matrix.target }}
       - run: mv "target/${{ matrix.target }}/release/ornithe-installer-rs" "target/${{ matrix.target }}/release/ornithe-installer-rs.bin"
         if: runner.os != 'Windows'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,23 @@ base64 = "0.22.1"
 chrono = { version = "0.4.40", features = ["serde"] }
 clap = { version = "4.5.35", features = ["cargo", "derive", "string"] }
 cli-clipboard = "0.4.0"
-eframe = { version = "0.31.1", features = ["wgpu"] }
-egui = "0.31.1"
-egui-dropdown = "0.13.0"
+eframe = { version = "0.31.1", features = ["wgpu"], optional = true }
+egui = { version = "0.31.1", optional = true }
+egui-dropdown = { version = "0.13.0", optional = true }
 env_logger = "0.11.8"
 log = "0.4.27"
 reqwest = { version = "0.12.15", features = ["json"] }
-rfd = "0.15.3"
+rfd = { version = "0.15.3", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
-webbrowser = "1.0.4"
+webbrowser = { version = "1.0.4", optional = true }
 zip = { version = "2.6.1", features = ["deflate-flate2"] }
+
+[features]
+default = ["gui"]
+
+gui = ["dep:eframe", "dep:egui", "dep:egui-dropdown", "dep:rfd", "dep:webbrowser"]
 
 [build-dependencies]
 embed-resource = "1.6.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,14 @@ publishing {
                         "exe" else "bin"
                 )
             }
+            artifact (
+                file(
+                    "$projectDir/target/$target/release/ornithe-installer-rs-cli." + if (os?.contains("windows") == true) // thanks kotlin
+                        "exe" else "bin"
+                )
+            ) {
+                classifier = "cli"
+            }
         }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@ use std::{fmt::Debug, path::StripPrefixError};
 #[derive(Debug)]
 pub struct InstallerError(pub String);
 
+#[cfg(feature = "gui")]
 impl From<eframe::Error> for InstallerError {
     fn from(value: eframe::Error) -> Self {
         InstallerError(format!("{:?}", value))

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ async fn main() {
     info!("Ornithe Installer v{}", VERSION);
 
     // The first argument is the binary name
+    #[cfg(feature = "gui")]
     if std::env::args().count() <= 1 {
         if let Ok(_) = crate::ui::gui::run().await {
             return;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
 pub mod cli;
+
+#[cfg(feature = "gui")]
 pub mod gui;
 
 #[derive(PartialEq, Clone, Copy, Debug)]


### PR DESCRIPTION
Allows for reduced binary size and faster compile times when only the CLI is required
I mark this as a WIP in progress bc I am unsure how to publish a second binary through gradle with github actions

Tested on linux:
Debug: 367.1MiB -> 110.2MiB
Release: 19.1MiB -> 5.6MiB